### PR TITLE
fix conflict between paper's adventure API and the shaded dependency 

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     shadow("com.fasterxml.jackson.core:jackson-annotations:2.17.0")
     shadow("com.fasterxml.jackson.core:jackson-core:2.17.0")
     shadow("com.fasterxml.jackson.core:jackson-databind:2.17.0")
-    implementation("net.kyori:adventure-api:4.18.0")
     compileOnly("com.github.retrooper:packetevents-api:2.10.0")
     compileOnly("org.geysermc.geyser:core:2.9.0-SNAPSHOT")
     compileOnly("org.geysermc.floodgate:core:2.2.5-SNAPSHOT")


### PR DESCRIPTION
Fixes #50 but has the following errors:

paper - extension - NoSuchMethodError: getHeader() https://mclo.gs/DWxae1o
paper - plugin - working fine
spigot - extension - java.lang.NoClassDefFoundError: net/kyori/adventure/text/Component https://mclo.gs/VWuiT8P
spigot - plugin - working fine

The issue on spigot extension exists on versions older than BETA 10 as well, so merging this would bring the plugin back to the previous state.
Regarding the issue on the extension running on paper: I don't have an idea as of now how to fix the error, I do see that the error is documented in the comments of [JavaTabListInjector](https://github.com/GeyserExtras/GeyserExtras/blob/318a75491c8d551363f2aad8a211120fbd4a8cc0/core/src/main/java/dev/letsgoaway/geyserextras/core/injectors/java/JavaTabListInjector.java#L21) 